### PR TITLE
Add cranial width analysis notebook

### DIFF
--- a/analisis_craneos.ipynb
+++ b/analisis_craneos.ipynb
@@ -1,0 +1,339 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Análisis de anchura de cráneos egipcios\n",
+        "\n",
+        "Este cuaderno guía el análisis descriptivo e inferencial solicitado para comparar la anchura de cráneos entre el periodo predinástico temprano (código 1) y el predinástico tardío (código 2). Incluye:\n",
+        "\n",
+        "- Estadísticos de centralización, dispersión, asimetría y curtosis por submuestra.\n",
+        "- Diagramas de caja y bigotes.\n",
+        "- Contrastación de normalidad (Kolmogorov-Smirnov).\n",
+        "- Intervalos de confianza para la diferencia de medias en tres niveles.\n",
+        "- Test *t* para comparar las medias y discusión de sus supuestos.\n",
+        "\n",
+        "Sigue las celdas de arriba a abajo y sustituye la ruta del archivo por la ubicación de tu Excel editable para trabajar con tus propios datos."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Configuración de datos\n",
+        "\n",
+        "- El archivo debe contener una columna con los códigos del periodo (`1` = predinástico temprano, `2` = predinástico tardío).\n",
+        "- Otra columna debe contener la anchura de los cráneos en milímetros.\n",
+        "- Ajusta la ruta del archivo, el nombre de la hoja y los nombres de columnas en la celda siguiente si tu estructura difiere.\n",
+        "\n",
+        "Si el archivo no está disponible en la ruta indicada, se cargará un conjunto de datos de ejemplo meramente ilustrativo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pathlib\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from scipy import stats\n",
+        "import seaborn as sns\n",
+        "import matplotlib.pyplot as plt\n",
+        "from IPython.display import Markdown, display\n",
+        "\n",
+        "# Ruta al archivo Excel editable con los datos reales\n",
+        "DATA_PATH = pathlib.Path('data/craneos.xlsx')  # actualiza según corresponda\n",
+        "SHEET_NAME = 0  # si tu Excel tiene varias hojas, ajusta el índice o el nombre\n",
+        "COLUMN_PERIOD = 'periodo'\n",
+        "COLUMN_WIDTH = 'anchura_mm'\n",
+        "\n",
+        "np.random.seed(42)\n",
+        "\n",
+        "if DATA_PATH.exists():\n",
+        "    df = pd.read_excel(DATA_PATH, sheet_name=SHEET_NAME)\n",
+        "    # Renombrar columnas si es necesario para asegurar consistencia\n",
+        "    df = df.rename(columns={df.columns[0]: COLUMN_PERIOD, df.columns[1]: COLUMN_WIDTH})\n",
+        "    source_note = f'Datos cargados desde {DATA_PATH}'\n",
+        "else:\n",
+        "    # Conjunto de datos ilustrativo para que el cuaderno pueda ejecutarse sin el Excel original\n",
+        "    early = np.random.normal(loc=135, scale=4.5, size=32)\n",
+        "    late = np.random.normal(loc=138, scale=5.0, size=29)\n",
+        "    df = pd.DataFrame({\n",
+        "        COLUMN_PERIOD: np.concatenate([np.repeat(1, len(early)), np.repeat(2, len(late))]),\n",
+        "        COLUMN_WIDTH: np.concatenate([early, late]),\n",
+        "    })\n",
+        "    source_note = 'Datos de ejemplo generados aleatoriamente (reemplaza por tu Excel para el análisis real)'\n",
+        "\n",
+        "# Depuración mínima para conservar solo registros válidos\n",
+        "clean_df = df[[COLUMN_PERIOD, COLUMN_WIDTH]].dropna()\n",
+        "clean_df[COLUMN_PERIOD] = clean_df[COLUMN_PERIOD].astype(int)\n",
+        "\n",
+        "print(source_note)\n",
+        "clean_df.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Estadísticos descriptivos por periodo\n",
+        "\n",
+        "Se calculan medidas de centralización (media, mediana, moda), dispersión (desviación típica, varianza, rango intercuartílico), asimetría y curtosis para cada submuestra. También se muestra el número de observaciones para controlar el tamaño muestral."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def compute_descriptives(series: pd.Series) -> pd.Series:\n",
+        "    mode_vals = series.mode()\n",
+        "    mode = mode_vals.iloc[0] if not mode_vals.empty else np.nan\n",
+        "    return pd.Series({\n",
+        "        'n': series.count(),\n",
+        "        'media': series.mean(),\n",
+        "        'mediana': series.median(),\n",
+        "        'moda': mode,\n",
+        "        'desviacion_tipica': series.std(ddof=1),\n",
+        "        'varianza': series.var(ddof=1),\n",
+        "        'q1': series.quantile(0.25),\n",
+        "        'q3': series.quantile(0.75),\n",
+        "        'rango_intercuartil': series.quantile(0.75) - series.quantile(0.25),\n",
+        "        'asimetria': stats.skew(series, bias=False),\n",
+        "        'curtosis': stats.kurtosis(series, fisher=True, bias=False),\n",
+        "    })\n",
+        "\n",
+        "descriptive_table = (\n",
+        "    clean_df\n",
+        "    .groupby(COLUMN_PERIOD)[COLUMN_WIDTH]\n",
+        "    .apply(compute_descriptives)\n",
+        "    .unstack(0)\n",
+        ")\n",
+        "\n",
+        "# Reordenar columnas para mayor legibilidad\n",
+        "ordered_columns = sorted(descriptive_table.columns)\n",
+        "descriptive_table = descriptive_table[ordered_columns]\n",
+        "\n",
+        "descriptive_table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "display(Markdown(\n",
+        "    '**Comentario:** Observa las diferencias entre periodos.\n",
+        "\n",
+        "'\n",
+        "    '- La media y mediana permiten comparar la tendencia central, mientras que el IQR y la desviación típica cuantifican la dispersión.\n",
+        "'\n",
+        "    '- Valores de asimetría cercanos a 0 sugieren simetría; la curtosis próxima a 0 se asemeja a la normal estándar.\n",
+        "'\n",
+        "    '- Utiliza estos valores para responder si las anchuras cambian entre periodos y si alguna distribución presenta colas largas o sesgo.'\n",
+        "))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Diagramas de caja y bigotes\n",
+        "\n",
+        "El diagrama resume medianas, cuartiles y posibles valores atípicos diferenciando cada periodo histórico."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "sns.set(style='whitegrid')\n",
+        "plt.figure(figsize=(8, 5))\n",
+        "ax = sns.boxplot(data=clean_df, x=COLUMN_PERIOD, y=COLUMN_WIDTH, palette='Set2')\n",
+        "ax.set_xlabel('Periodo (1 = predinástico temprano, 2 = predinástico tardío)')\n",
+        "ax.set_ylabel('Anchura de cráneo (mm)')\n",
+        "ax.set_title('Distribución de la anchura de cráneos por periodo')\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Test de normalidad (Kolmogorov-Smirnov)\n",
+        "\n",
+        "El test KS compara la distribución empírica de cada submuestra con una normal teórica usando su media y desviación típica. Un *p*-valor grande (por ejemplo, > 0.05) indica que no hay evidencia fuerte contra la normalidad."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def ks_test_normality(series: pd.Series) -> pd.Series:\n",
+        "    mean = series.mean()\n",
+        "    std = series.std(ddof=0)\n",
+        "    stat, pvalue = stats.kstest(series, 'norm', args=(mean, std))\n",
+        "    return pd.Series({'ks_stat': stat, 'pvalue': pvalue, 'media': mean, 'desv': std})\n",
+        "\n",
+        "ks_results = clean_df.groupby(COLUMN_PERIOD)[COLUMN_WIDTH].apply(ks_test_normality).unstack(0)\n",
+        "ks_results"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "for period, result in ks_results.items():\n",
+        "    conclusion = 'no se rechaza' if result['pvalue'] > 0.05 else 'se rechaza'\n",
+        "    display(Markdown(\n",
+        "        f\"**Periodo {period}:** KS = {result['ks_stat']:.3f}, *p* = {result['pvalue']:.3f}. \"\n",
+        "        f\"Con α = 0.05 se {conclusion} la normalidad.\"\n",
+        "    ))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Intervalos de confianza para la diferencia de medias\n",
+        "\n",
+        "Se calcula la diferencia \\(\\mu_{1} - \\mu_{2}\\) usando el método de Welch (varianzas no supuestas iguales). Se incluyen los niveles de confianza 90%, 95% y 99%."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def welch_se_and_df(series_a: pd.Series, series_b: pd.Series):\n",
+        "    var_a, var_b = series_a.var(ddof=1), series_b.var(ddof=1)\n",
+        "    n_a, n_b = series_a.count(), series_b.count()\n",
+        "    se = np.sqrt(var_a / n_a + var_b / n_b)\n",
+        "    df_num = (var_a / n_a + var_b / n_b) ** 2\n",
+        "    df_den = (var_a**2 / (n_a**2 * (n_a - 1))) + (var_b**2 / (n_b**2 * (n_b - 1)))\n",
+        "    df = df_num / df_den\n",
+        "    return se, df\n",
+        "\n",
+        "grouped = clean_df.groupby(COLUMN_PERIOD)[COLUMN_WIDTH]\n",
+        "series1 = grouped.get_group(1)\n",
+        "series2 = grouped.get_group(2)\n",
+        "\n",
+        "diff_means = series1.mean() - series2.mean()\n",
+        "se_diff, df_welch = welch_se_and_df(series1, series2)\n",
+        "\n",
+        "confidence_levels = [0.90, 0.95, 0.99]\n",
+        "records = []\n",
+        "for level in confidence_levels:\n",
+        "    alpha = 1 - level\n",
+        "    t_crit = stats.t.ppf(1 - alpha / 2, df=df_welch)\n",
+        "    margin = t_crit * se_diff\n",
+        "    lower = diff_means - margin\n",
+        "    upper = diff_means + margin\n",
+        "    records.append({\n",
+        "        'nivel_confianza': level,\n",
+        "        'limite_inferior': lower,\n",
+        "        'limite_superior': upper,\n",
+        "        't_critico': t_crit,\n",
+        "        'grados_libertad': df_welch,\n",
+        "    })\n",
+        "\n",
+        "ci_table = pd.DataFrame.from_records(records)\n",
+        "ci_table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "direction = 'mayor' if diff_means > 0 else 'menor'\n",
+        "period_wider = 1 if diff_means > 0 else 2\n",
+        "story = (\n",
+        "    f\"La diferencia de medias (periodo 1 - periodo 2) es {diff_means:.2f} mm, lo que sugiere \"\n",
+        "    f\"que el periodo {period_wider} presenta anchuras {direction}es. \"\n",
+        "    'Revisa si los intervalos contienen el 0: si no lo incluyen, la diferencia es compatible con ser distinta de cero al nivel indicado.'\n",
+        ")\n",
+        "display(Markdown(f\"**Interpretación preliminar:** {story}\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Test *t* para la igualdad de medias\n",
+        "\n",
+        "Se realiza el test *t* de Welch (no asume varianzas iguales). También se reporta el test de Levene para evaluar homocedasticidad. Recuerda que el test *t* requiere:\n",
+        "\n",
+        "1. Independencia de las observaciones (asumida).\n",
+        "2. Normalidad aproximada en cada grupo o muestras grandes (ver test KS).\n",
+        "3. Igualdad de varianzas si se usa la versión clásica; el método de Welch relaja este supuesto."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "levene_stat, levene_p = stats.levene(series1, series2)\n",
+        "welch_t, welch_p = stats.ttest_ind(series1, series2, equal_var=False)\n",
+        "pooled_t, pooled_p = stats.ttest_ind(series1, series2, equal_var=True)\n",
+        "\n",
+        "summary_rows = [\n",
+        "    {'prueba': 'Levene (varianzas iguales)', 'estadistico': levene_stat, 'pvalue': levene_p},\n",
+        "    {'prueba': 't de Welch (varianzas desiguales)', 'estadistico': welch_t, 'pvalue': welch_p},\n",
+        "    {'prueba': 't clásica (varianzas iguales)', 'estadistico': pooled_t, 'pvalue': pooled_p},\n",
+        "]\n",
+        "test_table = pd.DataFrame(summary_rows)\n",
+        "test_table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "levene_conclusion = 'se rechaza' if levene_p < 0.05 else 'no se rechaza'\n",
+        "welch_conclusion = 'diferencia significativa' if welch_p < 0.05 else 'sin evidencia de diferencia'\n",
+        "pooled_conclusion = 'diferencia significativa' if pooled_p < 0.05 else 'sin evidencia de diferencia'\n",
+        "\n",
+        "text = (\n",
+        "    f\"- **Levene:** p = {levene_p:.3f} → {levene_conclusion} la igualdad de varianzas a α = 0.05.\n",
+        "\"\n",
+        "    f\"- **t de Welch:** t = {welch_t:.2f}, p = {welch_p:.3f} → {welch_conclusion} entre medias.\n",
+        "\"\n",
+        "    f\"- **t clásica:** t = {pooled_t:.2f}, p = {pooled_p:.3f} → {pooled_conclusion} (interpretar solo si Levene sugiere varianzas similares).\"\n",
+        ")\n",
+        "display(Markdown(text))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook to analyze cranial width data by predynastic period
- include descriptive statistics, boxplots, normality checks, confidence intervals, and t-tests for the difference of means

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f40a68048832c90b332e0e98d8d32)